### PR TITLE
Set default language for LMS to EN. Currently it's set to 'C' - which…

### DIFF
--- a/Custom.pm
+++ b/Custom.pm
@@ -33,6 +33,8 @@ sub initDetails {
 	return $class->{osDetails};
 }
 
+sub getSystemLanguage { 'EN' }
+
 sub localeDetails {
 	my $lc_ctype = 'utf8';
 	my $lc_time = 'C';


### PR DESCRIPTION
… results in odd behavior and accidental switching to Danish etc.