### PR TITLE
Fix url for update instructions (German only)

### DIFF
--- a/custom-strings.txt
+++ b/custom-strings.txt
@@ -3,7 +3,7 @@
 # Release 1.0
 #
 PICORE_UPDATE_AVAILABLE
-	DE	Eine neue Version von Logitech Media Server ist verfügbar (%s). <a href="/html/doc/picore-update.html?installerFile=%s" target="update">Klicken Sie hier für weitere Instruktionen</a>.
+	DE	Eine neue Version von Logitech Media Server ist verfügbar (%s). <a href="/html/docs/picore-update.html?installerFile=%s" target="update">Klicken Sie hier für weitere Instruktionen</a>.
 	EN	A new version of Logitech Media Server is available (%s). <a href="/html/docs/picore-update.html?installerFile=%s" target="update">Click here for further information</a>.         
 	FR	Une nouvelle version de Logitech Media Server est disponible (%s). <a href="/html/docs/picore-update.html?installerFile=%s" target="update">Cliquez ici pour plus d'info</a>.
 	NL	Er is een nieuwe versie van Logitech Media Server beschikbaar (%s). <a href="/html/docs/picore-update.html?installerFile=%s" target="update">Klik op hier</a>.


### PR DESCRIPTION
The url in the German translation was missing a character, resulting in an empty page.